### PR TITLE
Draw forecast of now+[3,6,9,12] hours

### DIFF
--- a/espaper-weatherstation.ino
+++ b/espaper-weatherstation.ino
@@ -292,11 +292,24 @@ void drawCurrentWeather() {
 
 }
 
+unsigned int hourAddWrap(unsigned int hour, unsigned int add) {
+  hour += add;
+  if(hour > 23) hour -= 24;
+
+  return hour;
+}
+
 void drawForecast() {
-  drawForecastDetail(SCREEN_WIDTH / 2 - 20, 15, 3);
-  drawForecastDetail(SCREEN_WIDTH / 2 + 22, 15, 6);
-  drawForecastDetail(SCREEN_WIDTH / 2 + 64, 15, 9);
-  drawForecastDetail(SCREEN_WIDTH / 2 + 106, 15, 12);
+  time_t now = dstAdjusted.time(nullptr);
+  struct tm * timeinfo = localtime (&now);
+  
+  unsigned int curHour = timeinfo->tm_hour;
+  if(timeinfo->tm_min > 29) curHour = hourAddWrap(curHour, 1);
+
+  drawForecastDetail(SCREEN_WIDTH / 2 - 20, 15, hourAddWrap(curHour, 3));
+  drawForecastDetail(SCREEN_WIDTH / 2 + 22, 15, hourAddWrap(curHour, 6));
+  drawForecastDetail(SCREEN_WIDTH / 2 + 64, 15, hourAddWrap(curHour, 9));
+  drawForecastDetail(SCREEN_WIDTH / 2 + 106, 15, hourAddWrap(curHour, 12));
 }
 
 // helper for the forecast columns


### PR DESCRIPTION
Previously the absolute hours 3,6,9,12 were drawn.

A simple helper function handles the 24 hour wrap around. Note that if minutes are 30+, one additional hour is added for rounding.